### PR TITLE
Added new and legacy strategies.

### DIFF
--- a/DragScroll/main.c
+++ b/DragScroll/main.c
@@ -1,12 +1,13 @@
 #include <ApplicationServices/ApplicationServices.h>
 
-#define DEFAULT_BUTTON 5
+#define DEFAULT_BUTTON 3
 #define DEFAULT_KEYS kCGEventFlagMaskShift
-#define DEFAULT_SPEED 3
+#define DEFAULT_SPEED 2
 #define MAX_KEY_COUNT 5
+#define HOLD_THRESHOLD 0.3
 #define EQ(x, y) (CFStringCompare(x, y, kCFCompareCaseInsensitive) == kCFCompareEqualTo)
 
-static const CFStringRef AX_NOTIFICATION = CFSTR("com.apple.accessibility.api");
+static CFStringRef AX_NOTIFICATION;
 static bool TRUSTED;
 
 static int BUTTON;
@@ -17,45 +18,168 @@ static bool BUTTON_ENABLED;
 static bool KEY_ENABLED;
 static CGPoint POINT;
 
-static void maybeSetPointAndWarpMouse(bool thisEnabled, bool otherEnabled, CGEventRef event)
+typedef struct
 {
-    if (!otherEnabled) {
+    CGPoint location;
+    bool isHolding;
+    CFAbsoluteTime pressStartTime;
+    int lastDeltaX;
+    int lastDeltaY;
+} MouseState;
+
+static MouseState mouseState = {0};
+static bool legacyMode = false;
+
+static void maybeSetPointAndWarpMouse(bool thisEnabled, bool otherEnabled,
+                                      CGEventRef event)
+{
+    if (!otherEnabled)
+    {
         POINT = CGEventGetLocation(event);
-        CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStateCombinedSessionState);
-        if (thisEnabled) {
+
+        CGEventSourceRef source =
+            CGEventSourceCreate(kCGEventSourceStateCombinedSessionState);
+
+        if (thisEnabled)
+        {
             CGEventSourceSetLocalEventsSuppressionInterval(source, 10.0);
             CGWarpMouseCursorPosition(POINT);
-        } else {
+        }
+        else
+        {
             CGEventSourceSetLocalEventsSuppressionInterval(source, 0.0);
             CGWarpMouseCursorPosition(POINT);
             CGEventSourceSetLocalEventsSuppressionInterval(source, 0.25);
         }
+
         CFRelease(source);
     }
 }
 
-static CGEventRef tapCallback(CGEventTapProxy proxy,
-                              CGEventType type, CGEventRef event, void *userInfo)
+static CGEventRef handleMouseDrag(CGEventTapProxy proxy, CGEventRef event)
 {
-    if (type == kCGEventMouseMoved && (BUTTON_ENABLED || KEY_ENABLED)) {
+    mouseState.isHolding = true;
+    mouseState.lastDeltaX = (int)CGEventGetIntegerValueField(event, kCGMouseEventDeltaX);
+    mouseState.lastDeltaY = (int)CGEventGetIntegerValueField(event, kCGMouseEventDeltaY);
+
+    CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(
+        NULL, kCGScrollEventUnitPixel, 2,
+        -SPEED * mouseState.lastDeltaY,
+        -SPEED * mouseState.lastDeltaX);
+
+    if (scrollEvent)
+    {
+        CGEventSetLocation(scrollEvent, mouseState.location);
+        CGEventTapPostEvent(proxy, scrollEvent);
+        CFRelease(scrollEvent);
+    }
+
+    CGWarpMouseCursorPosition(mouseState.location);
+    return NULL;
+}
+
+static CGEventRef tapCallback(CGEventTapProxy proxy, CGEventType type,
+                              CGEventRef event, void *userInfo)
+{
+    const char *eventName;
+
+    switch (type)
+    {
+    case kCGEventLeftMouseDown:
+        eventName = "LeftMouseDown";
+        break;
+    case kCGEventLeftMouseUp:
+        eventName = "LeftMouseUp";
+        break;
+    case kCGEventRightMouseDown:
+        eventName = "RightMouseDown";
+        break;
+    case kCGEventRightMouseUp:
+        eventName = "RightMouseUp";
+        break;
+    case kCGEventMouseMoved:
+        eventName = "MouseMoved";
+        break;
+    case kCGEventLeftMouseDragged:
+        eventName = "LeftMouseDragged";
+        break;
+    case kCGEventRightMouseDragged:
+        eventName = "RightMouseDragged";
+        break;
+    case kCGEventOtherMouseDown:
+        eventName = "OtherMouseDown";
+        break;
+    case kCGEventOtherMouseUp:
+        eventName = "OtherMouseUp";
+        break;
+    case kCGEventOtherMouseDragged:
+        eventName = "OtherMouseDragged";
+        break;
+    case kCGEventScrollWheel:
+        eventName = "ScrollWheel";
+        break;
+    case kCGEventFlagsChanged:
+        eventName = "FlagsChanged";
+        break;
+    default:
+        eventName = "Other";
+        break;
+    }
+
+    if (legacyMode)
+    {
+        if (type == kCGEventOtherMouseDown &&
+            CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber) == BUTTON)
+        {
+            BUTTON_ENABLED = !BUTTON_ENABLED;
+            maybeSetPointAndWarpMouse(BUTTON_ENABLED, KEY_ENABLED, event);
+            return NULL;
+        }
+    }
+    else
+    {
+        if (type == kCGEventOtherMouseDown &&
+            CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber) == BUTTON)
+        {
+            BUTTON_ENABLED = true;
+            maybeSetPointAndWarpMouse(true, KEY_ENABLED, event);
+            POINT = CGEventGetLocation(event);
+            return event;
+        }
+        else if (type == kCGEventOtherMouseUp &&
+                 CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber) == BUTTON)
+        {
+            BUTTON_ENABLED = false;
+            maybeSetPointAndWarpMouse(false, KEY_ENABLED, event);
+            return event;
+        }
+    }
+
+    if ((type == kCGEventMouseMoved || type == kCGEventOtherMouseDragged) && (BUTTON_ENABLED || KEY_ENABLED))
+    {
+        CGPoint currentLocation = CGEventGetLocation(event);
         int deltaX = (int)CGEventGetIntegerValueField(event, kCGMouseEventDeltaX);
         int deltaY = (int)CGEventGetIntegerValueField(event, kCGMouseEventDeltaY);
-        CGEventRef scrollWheelEvent = CGEventCreateScrollWheelEvent(
-            NULL, kCGScrollEventUnitPixel, 2, -SPEED * deltaY, -SPEED * deltaX
-        );
+
+        CGEventRef scrollEvent = CGEventCreateScrollWheelEvent(
+            NULL, kCGScrollEventUnitPixel, 2,
+            -SPEED * deltaY,
+            -SPEED * deltaX);
+
+        CGEventSetLocation(scrollEvent, currentLocation);
+
         if (KEY_ENABLED)
-            CGEventSetFlags(scrollWheelEvent, CGEventGetFlags(event) & ~KEYS);
-        CGEventTapPostEvent(proxy, scrollWheelEvent);
-        CFRelease(scrollWheelEvent);
-        CGWarpMouseCursorPosition(POINT);
-        event = NULL;
-    } else if (type == kCGEventOtherMouseDown
-               && CGEventGetFlags(event) == 0
-               && CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber) == BUTTON) {
-        BUTTON_ENABLED = !BUTTON_ENABLED;
-        maybeSetPointAndWarpMouse(BUTTON_ENABLED, KEY_ENABLED, event);
-        event = NULL;
-    } else if (type == kCGEventFlagsChanged) {
+        {
+            CGEventSetFlags(scrollEvent, CGEventGetFlags(event) & ~KEYS);
+        }
+
+        CGEventTapPostEvent(proxy, scrollEvent);
+        CFRelease(scrollEvent);
+
+        return NULL;
+    }
+    else if (type == kCGEventFlagsChanged)
+    {
         KEY_ENABLED = (CGEventGetFlags(event) & KEYS) == KEYS;
         maybeSetPointAndWarpMouse(KEY_ENABLED, BUTTON_ENABLED, event);
     }
@@ -65,11 +189,8 @@ static CGEventRef tapCallback(CGEventTapProxy proxy,
 
 static void displayNoticeAndExit(CFStringRef alertHeader)
 {
-    CFUserNotificationDisplayNotice(
-        0, kCFUserNotificationCautionAlertLevel,
-        NULL, NULL, NULL,
-        alertHeader, NULL, NULL
-    );
+    CFUserNotificationDisplayNotice(0, kCFUserNotificationCautionAlertLevel,
+                                    NULL, NULL, NULL, alertHeader, NULL, NULL);
 
     exit(EXIT_FAILURE);
 }
@@ -78,118 +199,175 @@ static void notificationCallback(CFNotificationCenterRef center, void *observer,
                                  CFNotificationName name, const void *object,
                                  CFDictionaryRef userInfo)
 {
-    CFRunLoopRef runLoop = CFRunLoopGetCurrent();
-    CFRunLoopPerformBlock(
-        runLoop, kCFRunLoopDefaultMode, ^{
-            bool previouslyTrusted = TRUSTED;
-            if ((TRUSTED = AXIsProcessTrusted()) && !previouslyTrusted)
-                CFRunLoopStop(runLoop);
+    static bool previouslyTrusted = false;
+
+    if (!previouslyTrusted)
+    {
+        bool isTrusted = AXIsProcessTrusted();
+        if (isTrusted)
+        {
+            previouslyTrusted = true;
+            CFRunLoopStop(CFRunLoopGetCurrent());
         }
-    );
+    }
 }
 
-static bool getIntPreference(CFStringRef key, int *valuePtr)
+static bool getIntPreference(const CFStringRef key, int *valuePtr)
 {
     CFNumberRef number = (CFNumberRef)CFPreferencesCopyAppValue(
-        key, kCFPreferencesCurrentApplication
-    );
+        key, kCFPreferencesCurrentApplication);
     bool got = false;
-    if (number) {
-        if (CFGetTypeID(number) == CFNumberGetTypeID())
-            got = CFNumberGetValue(number, kCFNumberIntType, valuePtr);
+    if (number)
+    {
+        if (CFNumberGetValue(number, kCFNumberIntType, valuePtr))
+        {
+            got = true;
+        }
         CFRelease(number);
     }
-
     return got;
 }
 
-static bool getArrayPreference(CFStringRef key, CFStringRef *values, int *count, int maxCount)
+static bool getBoolPreference(const CFStringRef key, bool *valuePtr)
 {
-    CFArrayRef array = (CFArrayRef)CFPreferencesCopyAppValue(
-        key, kCFPreferencesCurrentApplication
-    );
+    CFBooleanRef boolRef = (CFBooleanRef)CFPreferencesCopyAppValue(key, kCFPreferencesCurrentApplication);
     bool got = false;
-    if (array) {
-        if (CFGetTypeID(array) == CFArrayGetTypeID()) {
-            CFIndex c = CFArrayGetCount(array);
-            if (c <= maxCount) {
-                CFArrayGetValues(array, CFRangeMake(0, c), (const void **)values);
-                *count = (int)c;
-                got = true;
-            }
+    if (boolRef)
+    {
+        if (CFGetTypeID(boolRef) == CFBooleanGetTypeID())
+        {
+            *valuePtr = CFBooleanGetValue(boolRef);
+            got = true;
         }
-        CFRelease(array);
+        CFRelease(boolRef);
+    }
+    return got;
+}
+
+static bool getArrayPreference(CFStringRef key, CFStringRef *values, int *count,
+                               int maxCount)
+{
+    if (!values || !count)
+        return false;
+
+    CFArrayRef array = (CFArrayRef)CFPreferencesCopyAppValue(
+        key, kCFPreferencesCurrentApplication);
+    bool got = false;
+
+    if (array && CFGetTypeID(array) == CFArrayGetTypeID())
+    {
+        CFIndex c = CFArrayGetCount(array);
+        if (c <= maxCount)
+        {
+            CFArrayGetValues(array, CFRangeMake(0, c), (const void **)values);
+            *count = (int)c;
+            got = true;
+        }
     }
 
+    if (array)
+        CFRelease(array);
     return got;
 }
 
 int main(void)
 {
+    AX_NOTIFICATION = CFSTR("com.apple.accessibility.api");
     CFNotificationCenterRef center = CFNotificationCenterGetDistributedCenter();
-    char observer;
+    static char observer;
+
     CFNotificationCenterAddObserver(
         center, &observer, notificationCallback, AX_NOTIFICATION, NULL,
-        CFNotificationSuspensionBehaviorDeliverImmediately
-    );
+        CFNotificationSuspensionBehaviorDeliverImmediately);
+
     CFDictionaryRef options = CFDictionaryCreate(
-        kCFAllocatorDefault,
-        (const void **)&kAXTrustedCheckOptionPrompt, (const void **)&kCFBooleanTrue, 1,
-        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks
-    );
+        kCFAllocatorDefault, (const void **)&kAXTrustedCheckOptionPrompt,
+        (const void **)&kCFBooleanTrue, 1, &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
     TRUSTED = AXIsProcessTrustedWithOptions(options);
     CFRelease(options);
+
     if (!TRUSTED)
         CFRunLoopRun();
-    CFNotificationCenterRemoveObserver(center, &observer, AX_NOTIFICATION, NULL);
+    CFNotificationCenterRemoveObserver(center, &observer, AX_NOTIFICATION,
+                                       NULL);
 
-    if (!(getIntPreference(CFSTR("button"), &BUTTON)
-          && (BUTTON == 0 || (BUTTON >= 3 && BUTTON <= 32))))
+    if (!(getIntPreference(CFSTR("button"), &BUTTON) &&
+          (BUTTON == 0 || (BUTTON >= 3 && BUTTON <= 32))))
         BUTTON = DEFAULT_BUTTON;
 
     CFStringRef keyNames[MAX_KEY_COUNT];
     int keyCount;
-    if (getArrayPreference(CFSTR("keys"), keyNames, &keyCount, MAX_KEY_COUNT)) {
+    if (getArrayPreference(CFSTR("keys"), keyNames, &keyCount, MAX_KEY_COUNT))
+    {
         KEYS = 0;
-        for (int i = 0; i < keyCount; i++) {
-            if (EQ(keyNames[i], CFSTR("capslock"))) {
+        for (int i = 0; i < keyCount; i++)
+        {
+            if (EQ(keyNames[i], CFSTR("capslock")))
+            {
                 KEYS |= kCGEventFlagMaskAlphaShift;
-            } else if (EQ(keyNames[i], CFSTR("shift"))) {
+            }
+            else if (EQ(keyNames[i], CFSTR("shift")))
+            {
                 KEYS |= kCGEventFlagMaskShift;
-            } else if (EQ(keyNames[i], CFSTR("control"))) {
+            }
+            else if (EQ(keyNames[i], CFSTR("control")))
+            {
                 KEYS |= kCGEventFlagMaskControl;
-            } else if (EQ(keyNames[i], CFSTR("option"))) {
+            }
+            else if (EQ(keyNames[i], CFSTR("option")))
+            {
                 KEYS |= kCGEventFlagMaskAlternate;
-            } else if (EQ(keyNames[i], CFSTR("command"))) {
+            }
+            else if (EQ(keyNames[i], CFSTR("command")))
+            {
                 KEYS |= kCGEventFlagMaskCommand;
-            } else {
+            }
+            else
+            {
                 KEYS = DEFAULT_KEYS;
                 break;
             }
         }
-    } else {
+    }
+    else
+    {
         KEYS = DEFAULT_KEYS;
     }
+
+    if (!getBoolPreference(CFSTR("legacy_button_hold_behaviour"), &legacyMode))
+        legacyMode = false;
 
     if (!getIntPreference(CFSTR("speed"), &SPEED))
         SPEED = DEFAULT_SPEED;
 
     CGEventMask events = CGEventMaskBit(kCGEventMouseMoved);
-    if (BUTTON != 0) {
-        events |= CGEventMaskBit(kCGEventOtherMouseDown);
+    if (BUTTON != 0)
+    {
+        events |= CGEventMaskBit(kCGEventOtherMouseDown) |
+                  CGEventMaskBit(kCGEventOtherMouseUp) |
+                  CGEventMaskBit(kCGEventOtherMouseDragged) |
+                  CGEventMaskBit(kCGEventLeftMouseDown) |
+                  CGEventMaskBit(kCGEventLeftMouseUp) |
+                  CGEventMaskBit(kCGEventLeftMouseDragged) |
+                  CGEventMaskBit(kCGEventRightMouseDown) |
+                  CGEventMaskBit(kCGEventRightMouseUp) |
+                  CGEventMaskBit(kCGEventRightMouseDragged);
         BUTTON--;
     }
     if (KEYS != 0)
         events |= CGEventMaskBit(kCGEventFlagsChanged);
-    CFMachPortRef tap = CGEventTapCreate(
-        kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault,
-        events, tapCallback, NULL
-    );
+    CFMachPortRef tap =
+        CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap,
+                         kCGEventTapOptionDefault, events, tapCallback, NULL);
     if (!tap)
-        displayNoticeAndExit(CFSTR("DragScroll could not create an event tap."));
-    CFRunLoopSourceRef source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
+        displayNoticeAndExit(
+            CFSTR("DragScroll could not create an event tap."));
+    CFRunLoopSourceRef source =
+        CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
     if (!source)
-        displayNoticeAndExit(CFSTR("DragScroll could not create a run loop source."));
+        displayNoticeAndExit(
+            CFSTR("DragScroll could not create a run loop source."));
     CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopDefaultMode);
     CFRelease(tap);
     CFRelease(source);

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It also works with the trackpad, for instance allowing you
 to drag scroll with a single finger
 while holding down the modifier keys.
 
-> [!NOTE]
+> **Note:**
 > The two means of activation operate independently of each other:
 > if you first press the mouse button to activate
 > and then press and release the modifier keys,
@@ -31,13 +31,13 @@ As of May 2024, this application works on macOS versions 10.9–14.0.
 
 ### Installation
 
-You may download the binary [here](https://github.com/emreyolcu/drag-scroll/releases/download/v1.3.1/DragScroll.zip).
+You may download the binary [here](https://github.com/emreyolcu/drag-scroll/releases/latest/download/DragScroll.zip).
 DragScroll requires access to accessibility features.
 Upon startup, if it does not have access, it will prompt you and wait.
 You do not need to restart the application
 after you grant it access to accessibility features.
 
-> [!CAUTION]
+> **Caution:**
 > You should not revoke accessibility access
 > for DragScroll while it is running.
 > Otherwise, your mouse might become unresponsive, requiring a reboot to fix.
@@ -59,7 +59,7 @@ or do the following:
 ### Configuration
 
 - **Mouse button**:
-  The default mouse button for toggling drag scrolling is button 5.
+  The default mouse button for toggling drag scrolling is button 3 (the middle one).
   If you want to use a different mouse button, run the following command,
   replacing `BUTTON` with a button number between 3 and 32.
   (Button numbers are one-based,
@@ -98,6 +98,19 @@ or do the following:
   defaults write com.emreyolcu.DragScroll keys -array
   ```
 
+- **Legacy button hold behaviour:** 
+  By default, DragScroll uses a modern, intuitive button hold behavior introduced in **v1.4.0**. If you prefer the legacy button hold behavior, run the following command:
+
+  ```
+  defaults write com.emreyolcu.DragScroll legacy_button_hold_behaviour -bool true
+  ```
+
+  To revert to the modern button hold behaviour, run:
+
+  ```
+  defaults write com.emreyolcu.DragScroll legacy_button_hold_behaviour -bool false
+  ```
+
 - **Scrolling speed:**
   If you want to change scrolling speed, run the following command,
   replacing `SPEED` with a small number (default is 3).
@@ -107,7 +120,7 @@ or do the following:
   defaults write com.emreyolcu.DragScroll speed -int SPEED
   ```
 
-> [!WARNING]
+> **Warning:**
 > If you set a preference to an unexpected value (e.g., of the wrong type),
 > then its default value is used as a fallback.
 
@@ -144,6 +157,10 @@ even though you have previously granted it access, try the following:
 2. Remove `DragScroll` from the list and add it again.
 
 ### History
+
+#### v1.4.0 (31.01.2025)
+
+- Added the ability to scroll by holding a button and handle single clicks separately.
 
 #### v1.3.1 (2024-06-05)
 


### PR DESCRIPTION
Added Windows-like middle button handling with `legacyMode` flag. This allows holding the middle mouse button to drag-scroll and single-click to close tabs, useful for users accustomed to Windows behavior.
* Changed default mouse button from 5 to 3 and default speed from 3 to 2.
* [`DragScroll/main.c`]: Added support for legacy button hold behavior with a new boolean flag `legacyMode` and updated the `tapCallback` function to handle this mode.
* [`README.md`]: Updated the installation link to point to the latest release and added instructions for enabling legacy button hold behavior.
* [`README.md`]: Added version history for v1.4.0, noting the new scrolling and single-click handling feature.
